### PR TITLE
Removed published parameter from store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This extension adds a new shiny button for adding code in a Trello comment.
 
 ## Install
 
-### [Add to Chrome](https://chrome.google.com/webstore/detail/lopmiphdibkigebkpicjacdcgcdianhd/publish-accepted?hl=sv)
+### [Add to Chrome](https://chrome.google.com/webstore/detail/lopmiphdibkigebkpicjacdcgcdianhd)
 
 ## Install manually
 


### PR DESCRIPTION
`/publish-accepted?hl=sv` prevents installing the extension because it treats it as your own.